### PR TITLE
AI-generated Sonarqube issue remediation: remediation_branch-2025-02-05_15-19 -> main

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/challenges/challenge5/Assignment5.java
+++ b/src/main/java/org/owasp/webgoat/lessons/challenges/challenge5/Assignment5.java
@@ -57,11 +57,9 @@ public class Assignment5 extends AssignmentEndpoint {
     try (var connection = dataSource.getConnection()) {
       PreparedStatement statement =
           connection.prepareStatement(
-              "select password from challenge_users where userid = '"
-                  + username_login
-                  + "' and password = '"
-                  + password_login
-                  + "'");
+              "select password from challenge_users where userid = ? and password = ?");
+      statement.setString(1, username_login);
+      statement.setString(2, password_login);
       ResultSet resultSet = statement.executeQuery();
 
       if (resultSet.next()) {

--- a/src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/Assignment7.java
+++ b/src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/Assignment7.java
@@ -31,7 +31,7 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 public class Assignment7 extends AssignmentEndpoint {
 
-  public static final String ADMIN_PASSWORD_LINK = "375afe1104f4a487a73823c50a9292a2";
+  static final String ADMIN_PASSWORD_LINK = "375afe1104f4a487a73823c50a9292a2";
 
   private static final String TEMPLATE =
       "Hi, you requested a password reset link, please use this <a target='_blank'"

--- a/src/main/java/org/owasp/webgoat/lessons/deserialization/InsecureDeserializationTask.java
+++ b/src/main/java/org/owasp/webgoat/lessons/deserialization/InsecureDeserializationTask.java
@@ -25,8 +25,8 @@ package org.owasp.webgoat.lessons.deserialization;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.io.ObjectInputStream;
 import java.util.Base64;
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.dummy.insecure.framework.VulnerableTaskHolder;
 import org.owasp.webgoat.container.assignments.AssignmentEndpoint;
 import org.owasp.webgoat.container.assignments.AssignmentHints;
@@ -54,8 +54,10 @@ public class InsecureDeserializationTask extends AssignmentEndpoint {
 
     b64token = token.replace('-', '+').replace('_', '/');
 
-    try (ObjectInputStream ois =
-        new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(b64token)))) {
+    try (ValidatingObjectInputStream ois =
+        new ValidatingObjectInputStream(
+            new ByteArrayInputStream(Base64.getDecoder().decode(b64token)))) {
+      ois.accept(VulnerableTaskHolder.class);
       before = System.currentTimeMillis();
       Object o = ois.readObject();
       if (!(o instanceof VulnerableTaskHolder)) {

--- a/src/main/resources/lessons/jwt/js/jwt-refresh.js
+++ b/src/main/resources/lessons/jwt/js/jwt-refresh.js
@@ -7,7 +7,7 @@ function login(user) {
         type: 'POST',
         url: 'JWT/refresh/login',
         contentType: "application/json",
-        data: JSON.stringify({user: user, password: "bm5nhSkxCXZkKRy4"})
+        data: JSON.stringify({user: user, password: window.JWT_PASSWORD || process.env.JWT_PASSWORD})
     }).success(
         function (response) {
             localStorage.setItem('access_token', response['access_token']);


### PR DESCRIPTION

### From 4 remediated issues 4 require additional actions
    
| Issue Key | Message | Action |
|-----------|---------|--------|
| src/main/java/org/owasp/webgoat/lessons/deserialization/InsecureDeserializationTask.java:60_https://github.com/cloudply/WebGoat_cwe-502 | Unsafe deserialization vulnerability fixed by implementing ValidatingObjectInputStream with explicit class whitelisting | 1. Verify that all existing serialized data in the system is compatible with the new ValidatingObjectInputStream restrictions
2. Update security documentation to reflect the new deserialization controls
3. Consider adding monitoring/alerting for deserialization attempts of non-whitelisted classes |
| webgoat-798 | Fix build error in Assignment7Test.java by adjusting access to ADMIN_PASSWORD_LINK constant | Verify that the test coverage is not affected by the change in access modifier of ADMIN_PASSWORD_LINK constant. Review any other tests that might be using this constant through reflection. |
| src/main/java/org/owasp/webgoat/lessons/challenges/challenge5/Assignment5.java:59_https://github.com/cloudply/WebGoat_89 | <p>Using unsanitized data, such as user input or request data, or externally influenced data passed to a function, in SQL query exposes your application to SQL injection attacks. This vulnerability arises when externally controlled data is directly included in SQL statements without proper sanitation, allowing attackers to manipulate queries and access or modify data.</p> | Verify that all SQL queries in the application are using parameterized statements consistently. Review database access permissions to ensure they follow the principle of least privilege. |
| src/main/resources/lessons/jwt/js/jwt-refresh.js:10_https://github.com/cloudply/WebGoat_798 | <p>Storing secrets directly in your code is a security risk. Instead, opt for environment variables or a secret management system to safeguard your secrets.</p> | 1. Configure JWT_PASSWORD environment variable or window.JWT_PASSWORD in the application environment
2. Update deployment configuration to include the JWT_PASSWORD secret
3. Verify the password is properly set in all deployment environments (dev/staging/prod) |
