### PR TITLE
AI-generated Sonarqube issue remediation: remediation_branch-2025-02-05_23-27 -> main

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/challenges/challenge5/Assignment5.java
+++ b/src/main/java/org/owasp/webgoat/lessons/challenges/challenge5/Assignment5.java
@@ -57,11 +57,9 @@ public class Assignment5 extends AssignmentEndpoint {
     try (var connection = dataSource.getConnection()) {
       PreparedStatement statement =
           connection.prepareStatement(
-              "select password from challenge_users where userid = '"
-                  + username_login
-                  + "' and password = '"
-                  + password_login
-                  + "'");
+              "select password from challenge_users where userid = ? and password = ?");
+      statement.setString(1, username_login);
+      statement.setString(2, password_login);
       ResultSet resultSet = statement.executeQuery();
 
       if (resultSet.next()) {

--- a/src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/Assignment7.java
+++ b/src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/Assignment7.java
@@ -31,7 +31,7 @@ import org.springframework.web.client.RestTemplate;
 @Slf4j
 public class Assignment7 extends AssignmentEndpoint {
 
-  public static final String ADMIN_PASSWORD_LINK = "375afe1104f4a487a73823c50a9292a2";
+  static final String ADMIN_PASSWORD_LINK = "375afe1104f4a487a73823c50a9292a2";
 
   private static final String TEMPLATE =
       "Hi, you requested a password reset link, please use this <a target='_blank'"

--- a/src/main/java/org/owasp/webgoat/lessons/deserialization/InsecureDeserializationTask.java
+++ b/src/main/java/org/owasp/webgoat/lessons/deserialization/InsecureDeserializationTask.java
@@ -25,8 +25,8 @@ package org.owasp.webgoat.lessons.deserialization;
 import java.io.ByteArrayInputStream;
 import java.io.IOException;
 import java.io.InvalidClassException;
-import java.io.ObjectInputStream;
 import java.util.Base64;
+import org.apache.commons.io.serialization.ValidatingObjectInputStream;
 import org.dummy.insecure.framework.VulnerableTaskHolder;
 import org.owasp.webgoat.container.assignments.AssignmentEndpoint;
 import org.owasp.webgoat.container.assignments.AssignmentHints;
@@ -54,8 +54,10 @@ public class InsecureDeserializationTask extends AssignmentEndpoint {
 
     b64token = token.replace('-', '+').replace('_', '/');
 
-    try (ObjectInputStream ois =
-        new ObjectInputStream(new ByteArrayInputStream(Base64.getDecoder().decode(b64token)))) {
+    try (ValidatingObjectInputStream ois =
+        new ValidatingObjectInputStream(
+            new ByteArrayInputStream(Base64.getDecoder().decode(b64token)))) {
+      ois.accept(VulnerableTaskHolder.class);
       before = System.currentTimeMillis();
       Object o = ois.readObject();
       if (!(o instanceof VulnerableTaskHolder)) {

--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -45,10 +45,12 @@ public class SSRFTask2 extends AssignmentEndpoint {
     return furBall(url);
   }
 
+  private static final String ALLOWED_URL = "http://ifconfig.pro";
+
   protected AttackResult furBall(String url) {
-    if (url.matches("http://ifconfig\\.pro")) {
+    if (ALLOWED_URL.equals(url)) {
       String html;
-      try (InputStream in = new URL(url).openStream()) {
+      try (InputStream in = new URL(ALLOWED_URL).openStream()) {
         html =
             new String(in.readAllBytes(), StandardCharsets.UTF_8)
                 .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response

--- a/src/main/resources/lessons/jwt/js/jwt-refresh.js
+++ b/src/main/resources/lessons/jwt/js/jwt-refresh.js
@@ -7,7 +7,7 @@ function login(user) {
         type: 'POST',
         url: 'JWT/refresh/login',
         contentType: "application/json",
-        data: JSON.stringify({user: user, password: "bm5nhSkxCXZkKRy4"})
+        data: JSON.stringify({user: user, password: window.JWT_PASSWORD || process.env.JWT_PASSWORD})
     }).success(
         function (response) {
             localStorage.setItem('access_token', response['access_token']);


### PR DESCRIPTION

### From 5 remediated issues 5 require additional actions
    
| Issue Key | Message | Action |
|-----------|---------|--------|
| cwe-502 | Unsafe deserialization vulnerability in InsecureDeserializationTask.java | Verify that the ValidatingObjectInputStream whitelisting is properly enforced across all deserialization operations in the application. Review other endpoints that might be using deserialization to ensure consistent security controls. |
| src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java:51_https://github.com/cloudply/WebGoat_cwe-918 | Making web requests based on unvalidated user-input may cause the server to communicate with malicious servers. | Verify that the application's security policy allows outbound connections to ifconfig.pro domain. Ensure the firewall rules permit this specific connection. |
| src/main/java/org/owasp/webgoat/lessons/challenges/challenge7/Assignment7.java:34 | Make ADMIN_PASSWORD_LINK accessible to tests while maintaining security | Verify that the test cases in other modules are not using the ADMIN_PASSWORD_LINK constant directly |
| src/main/java/org/owasp/webgoat/lessons/challenges/challenge5/Assignment5.java:59 | SQL injection vulnerability fixed by replacing string concatenation with PreparedStatement | Verify that all SQL queries in the application are using PreparedStatement consistently to prevent SQL injection vulnerabilities |
| src/main/resources/lessons/jwt/js/jwt-refresh.js:10_https://github.com/cloudply/WebGoat_798 | <p>Storing secrets directly in your code is a security risk. Instead, opt for environment variables or a secret management system to safeguard your secrets.</p> | 1. Configure JWT_PASSWORD environment variable in all deployment environments
2. Update deployment documentation to include JWT_PASSWORD configuration
3. Verify JWT_PASSWORD is properly set in development environments
4. Update application startup checks to validate JWT_PASSWORD is configured |
