### PR TITLE
Code scan issue remediation with AI:  remediation_branch-2025-04-02_18-29-issue-src_main_java_org_owasp_webgoat_lessons_ssrf_SSRFTask2_java_51_cwe_918 -> main

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -39,6 +39,8 @@ import org.springframework.web.bind.annotation.RestController;
 @AssignmentHints({"ssrf.hint3"})
 public class SSRFTask2 extends AssignmentEndpoint {
 
+  private static final String ALLOWED_URL = "http://ifconfig.pro";
+
   @PostMapping("/SSRF/task2")
   @ResponseBody
   public AttackResult completed(@RequestParam String url) {
@@ -48,10 +50,14 @@ public class SSRFTask2 extends AssignmentEndpoint {
   protected AttackResult furBall(String url) {
     if (url.matches("http://ifconfig\\.pro")) {
       String html;
-      try (InputStream in = new URL(url).openStream()) {
-        html =
-            new String(in.readAllBytes(), StandardCharsets.UTF_8)
-                .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response
+      try {
+        // Use the predefined allowed URL instead of user input directly
+        URL safeUrl = new URL(ALLOWED_URL);
+        try (InputStream in = safeUrl.openStream()) {
+          html =
+              new String(in.readAllBytes(), StandardCharsets.UTF_8)
+                  .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response
+        }
       } catch (MalformedURLException e) {
         return getFailedResult(e.getMessage());
       } catch (IOException e) {


### PR DESCRIPTION

### From 1 remediated issues 1 requires additional actions
| File                                                        | Rule      | Severity   | CVE/CWE   | Vulnerability Name          | Message                                                                                                         | Action                                                                                                                                                                                                                                                                     |
|-------------------------------------------------------------|-----------|------------|-----------|-----------------------------|-----------------------------------------------------------------------------------------------------------------|----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java | java/ssrf | CRITICAL   | cwe-918   | Server-side request forgery | Making web requests based on unvalidated user-input may cause the server to communicate with malicious servers. | Verify that the SSRF protection doesn't break the intended functionality of the lesson. Since this is a WebGoat application used for security training, the fix should protect against real SSRF while still allowing students to complete the intended learning exercise. |