### PR TITLE
Code scan issue remediation with AI:  remediation_branch-2025-04-03_06-55-issue-src_main_java_org_owasp_webgoat_lessons_ssrf_SSRFTask2_java_51_cwe_918 -> main

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
+++ b/src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java
@@ -39,6 +39,8 @@ import org.springframework.web.bind.annotation.RestController;
 @AssignmentHints({"ssrf.hint3"})
 public class SSRFTask2 extends AssignmentEndpoint {
 
+  private static final String ALLOWED_URL = "http://ifconfig.pro";
+
   @PostMapping("/SSRF/task2")
   @ResponseBody
   public AttackResult completed(@RequestParam String url) {
@@ -48,10 +50,13 @@ public class SSRFTask2 extends AssignmentEndpoint {
   protected AttackResult furBall(String url) {
     if (url.matches("http://ifconfig\\.pro")) {
       String html;
-      try (InputStream in = new URL(url).openStream()) {
-        html =
-            new String(in.readAllBytes(), StandardCharsets.UTF_8)
-                .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response
+      try {
+        // Use the validated, hardcoded URL instead of user input
+        try (InputStream in = new URL(ALLOWED_URL).openStream()) {
+          html =
+              new String(in.readAllBytes(), StandardCharsets.UTF_8)
+                  .replaceAll("\n", "<br>"); // Otherwise the \n gets escaped in the response
+        }
       } catch (MalformedURLException e) {
         return getFailedResult(e.getMessage());
       } catch (IOException e) {


### PR DESCRIPTION

### Remediated 1 issues
### Fixed issues summary
| File                                                        | Rule      | Severity   | CVE/CWE   | Vulnerability Name          |
|-------------------------------------------------------------|-----------|------------|-----------|-----------------------------|
| src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java | java/ssrf | CRITICAL   | cwe-918   | Server-side request forgery |
### From 1 remediated issues 1 requires additional actions
| File                                                        | Rule      | Message                                                                                                         | Action                                                                                                                                                                                    |
|-------------------------------------------------------------|-----------|-----------------------------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| src/main/java/org/owasp/webgoat/lessons/ssrf/SSRFTask2.java | java/ssrf | Making web requests based on unvalidated user-input may cause the server to communicate with malicious servers. | Verify that the application's SSRF protection tests still pass with the hardcoded URL approach. Consider implementing a whitelist approach if more URLs need to be allowed in the future. |