### PR TITLE
Code scan issue remediation with AI:  remediation_branch-2025-04-03_07-28-issue-src_main_java_org_owasp_webgoat_lessons_sqlinjection_advanced_SqlInjectionLesson6a_java_68_cwe_1333 -> main

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java
+++ b/src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java
@@ -65,7 +65,7 @@ public class SqlInjectionLesson6a extends AssignmentEndpoint {
       boolean usedUnion = true;
       query = "SELECT * FROM user_data WHERE last_name = '" + accountName + "'";
       // Check if Union is used
-      if (!accountName.matches("(?i)(^[^-/*;)]*)(\\s*)UNION(.*$)")) {
+      if (!accountName.matches("(?i).*\\s+union\\s+.*")) {
         usedUnion = false;
       }
       try (Statement statement =


### PR DESCRIPTION

### Remediated 1 issues

### Fixed issues summary
| File                                                                                    | Rule                  | Severity   | CVE/CWE                        | Vulnerability Name                                      |
|-----------------------------------------------------------------------------------------|-----------------------|------------|--------------------------------|---------------------------------------------------------|
| src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java | java/polynomial-redos | HIGH       | cwe-1333<br>cwe-730<br>cwe-400 | Polynomial regular expression used on uncontrolled data |
### From 1 remediated issues 1 have recommendations for additional actions
| File                                                                                    | Rule                  | Message                                                                                                        | Action                                                                                                                                                                            |
|-----------------------------------------------------------------------------------------|-----------------------|----------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
| src/main/java/org/owasp/webgoat/lessons/sqlinjection/advanced/SqlInjectionLesson6a.java | java/polynomial-redos | A regular expression that can require polynomial time to match may be vulnerable to denial-of-service attacks. | Verify that the regex change doesn't affect any legitimate SQL queries that might contain the word 'UNION' in a non-injection context (e.g., in column names or string literals). |