### PR TITLE
Code scan issue remediation with AI:  remediation_branch-2025-04-09_00-31-issue-src_main_java_org_owasp_webgoat_lessons_pathtraversal_ProfileZipSlip_java_73_cwe_022 -> main

### DIFF
--- a/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileZipSlip.java
+++ b/src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileZipSlip.java
@@ -71,6 +71,10 @@ public class ProfileZipSlip extends ProfileUploadBase {
       while (entries.hasMoreElements()) {
         ZipEntry e = entries.nextElement();
         File f = new File(tmpZipDirectory.toFile(), e.getName());
+        // Fix for Zip Slip vulnerability - validate the file path
+        if (!f.toPath().normalize().startsWith(tmpZipDirectory)) {
+          throw new IOException("Entry is outside of the target directory: " + e.getName());
+        }
         InputStream is = zip.getInputStream(e);
         Files.copy(is, f.toPath(), StandardCopyOption.REPLACE_EXISTING);
       }


### PR DESCRIPTION

### Remediated 1 issues

### Fixed issues summary
| File                                                                      | Rule         | Severity   | CVE/CWE   | Vulnerability Name                                           |
|---------------------------------------------------------------------------|--------------|------------|-----------|--------------------------------------------------------------|
| src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileZipSlip.java | java/zipslip | HIGH       | cwe-022   | Arbitrary file access during archive extraction ("Zip Slip") |
### From 1 remediated issues 1 have recommendations for additional actions
| File                                                                      | Rule         | Message                                                                                                                                                                                                                       | Action                                                                                                                                        |
|---------------------------------------------------------------------------|--------------|-------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|-----------------------------------------------------------------------------------------------------------------------------------------------|
| src/main/java/org/owasp/webgoat/lessons/pathtraversal/ProfileZipSlip.java | java/zipslip | Extracting files from a malicious ZIP file, or similar type of archive, without validating that the destination file path is within the destination directory can allow an attacker to unexpectedly gain access to resources. | Verify that the fix doesn't break legitimate ZIP file extraction functionality by testing with valid ZIP files containing nested directories. |